### PR TITLE
Removes provider block so module can be used directly as a root config

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0
+current_version = 3.0.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,3 @@
-provider "aws" {}
-
 resource "aws_s3_bucket" "this" {
   count = var.create_bucket ? 1 : 0
 


### PR DESCRIPTION
When the provider block is present, if the module is used directly
as a root config where the user is otherwise providing a provider
config (e.g. using terragrunt generate blocks), terraform fails
with an error similar to:

```
Error: Duplicate provider configuration

  on main.tf line 3:
   3: provider aws {

A default (non-aliased) provider configuration for "aws" was already given at
main.tf:1,1-13. If multiple configurations are required, set the "alias"
```

Results of `make test`:
```
PASS
ok      terraform-aws-tardigrade-s3-bucket/tests        222.475s
[terratest/test]: Completed successfully!
```