### PR TITLE
Bumps version to 4.3.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.2.0
+current_version = 4.3.0
 commit = True
 message = Bumps version to {new_version}
 tag = False


### PR DESCRIPTION
This will release the feature just merged that manages bucket lifecycle rules.